### PR TITLE
squid: S2696: Instance methods should not write to static fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-beta3'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.novoda:bintray-release:0.3.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 13 21:25:43 IRDT 2016
+#Fri Apr 29 20:19:34 IRDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip

--- a/library/src/main/java/io/github/meness/easyintro/AndroidUtils.java
+++ b/library/src/main/java/io/github/meness/easyintro/AndroidUtils.java
@@ -20,7 +20,12 @@ import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
-public class AndroidUtils {
+public final class AndroidUtils {
+
+    private AndroidUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not for instantiation");
+    }
+
     public static boolean hasVibratePermission(Context context) {
         int res = context.checkCallingOrSelfPermission(Manifest.permission.VIBRATE);
         return (res == PackageManager.PERMISSION_GRANTED);

--- a/library/src/main/java/io/github/meness/easyintro/EasyIntroSlidesInside.java
+++ b/library/src/main/java/io/github/meness/easyintro/EasyIntroSlidesInside.java
@@ -26,8 +26,8 @@ import java.util.List;
 public abstract class EasyIntroSlidesInside extends EasyIntroFragment {
     // first slide is the main one
     private static List<Fragment> mSlidesInside = new ArrayList<>();
-    private static int mCurrentSlideLocation = 0;
-    private static boolean mFirstInit;
+    private  int mCurrentSlideLocation = 0;
+    private  boolean mFirstInit;
 
     public final void withSlide(Fragment fragment) {
         mSlidesInside.add(fragment);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2696- “Instance methods should not write to "static" fields"
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2696
Please let me know if you have any questions.
Fevzi Ozgul